### PR TITLE
Fixed Handle return type (was return void)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ShortBus is a synchronous mediator with low-friction API
     public class AskAQuestion : IQuery<Answer> { }
 
 	public class Answerer : IQueryHandler<AskAQuestion, Answer> {
-	    public void Handle(AskAQuestion query) {			
+	    public Answer Handle(AskAQuestion query) {			
 			return answer;
 		}
 	}


### PR DESCRIPTION
Hi - great little project - going through the docs I noticed the query handler example returned void.
