### PR TITLE
Support Targets With Multiple Query Handler Implementations

### DIFF
--- a/ShortBus.Tests/Example/BasicExample.cs
+++ b/ShortBus.Tests/Example/BasicExample.cs
@@ -34,6 +34,19 @@ namespace ShortBus.Tests.Example
         }
 
         [Test]
+        public void RequestResponseImplementationWithMultipleHandler()
+        {
+            var query = new TriplePing();
+
+            var mediator = ObjectFactory.GetInstance<IMediator>();
+
+            var pong = mediator.Request(query);
+
+            Assert.That(pong.Data, Is.EqualTo("PONG! PONG! PONG!"));
+            Assert.That(pong.HasException(), Is.False);
+        }
+
+        [Test]
         public void RequestResponse_variant()
         {
             var query = new PingALing();
@@ -43,6 +56,19 @@ namespace ShortBus.Tests.Example
             var pong = mediator.Request(query);
 
             Assert.That(pong.Data, Is.EqualTo("PONG!"));
+            Assert.That(pong.HasException(), Is.False);
+        }
+
+        [Test]
+        public void RequestResponseImplementationWithMultipleHandler_variant()
+        {
+            var query = new DoublePingALing();
+
+            var mediator = ObjectFactory.GetInstance<IMediator>();
+
+            var pong = mediator.Request(query);
+
+            Assert.That(pong.Data, Is.EqualTo("PONG! PONG!"));
             Assert.That(pong.HasException(), Is.False);
         }
 

--- a/ShortBus.Tests/Example/MultiPing.cs
+++ b/ShortBus.Tests/Example/MultiPing.cs
@@ -1,0 +1,7 @@
+﻿namespace ShortBus.Tests.Example
+{
+    public class DoublePing : IQuery<string> {}
+    public class DoublePingALing : DoublePing {}
+    public class TriplePing : IQuery<string> {}
+    public class TriplePingALing : TriplePing {}
+}

--- a/ShortBus.Tests/Example/MultiPong.cs
+++ b/ShortBus.Tests/Example/MultiPong.cs
@@ -1,0 +1,17 @@
+﻿namespace ShortBus.Tests.Example
+{
+    public class MultiPong 
+    : IQueryHandler<DoublePing, string>,
+      IQueryHandler<TriplePing, string>
+    {
+        public string Handle(DoublePing request)
+        {
+            return "PONG! PONG!";
+        }
+
+        public string Handle(TriplePing request)
+        {
+            return "PONG! PONG! PONG!";
+        }
+    }
+}

--- a/ShortBus.Tests/ShortBus.Tests.csproj
+++ b/ShortBus.Tests/ShortBus.Tests.csproj
@@ -57,6 +57,8 @@
     <Compile Include="Example\AsyncExample.cs" />
     <Compile Include="Example\BasicExample.cs" />
     <Compile Include="Example\ConsoleWriter.cs" />
+    <Compile Include="Example\MultiPong.cs" />
+    <Compile Include="Example\MultiPing.cs" />
     <Compile Include="Example\Ping.cs" />
     <Compile Include="Example\Pong.cs" />
     <Compile Include="Example\PrintText.cs" />

--- a/ShortBus/Mediator.cs
+++ b/ShortBus/Mediator.cs
@@ -107,12 +107,18 @@ namespace ShortBus
 
         static TResponseData ProcessQueryWithHandler<TResponseData>(IQuery<TResponseData> query, object handler)
         {
-            return (TResponseData) handler.GetType().GetMethod("Handle").Invoke(handler, new object[] { query });
+            return (TResponseData) handler
+                .GetType()
+                .GetMethod("Handle", new Type[] {query.GetType()})
+                .Invoke(handler, new object[] {query});
         }
 
         static Task<TResponseData> ProcessQueryWithHandlerAsync<TResponseData>(IAsyncQuery<TResponseData> query, object handler)
         {
-            return (Task<TResponseData>) handler.GetType().GetMethod("HandleAsync").Invoke(handler, new object[] { query });
+            return (Task<TResponseData>) handler
+                .GetType()
+                .GetMethod("HandleAsync", new Type[] {query.GetType()})
+                .Invoke(handler, new object[] {query});
         }
 
         object GetHandler<TResponseData>(IQuery<TResponseData> query)


### PR DESCRIPTION
Enhanced the Mediator.ProcessQueryWithHandler and Mediator.ProcessQueryWithHandlerAsync methods so they perform a more specific method search against the resolved handler. This is accomplished by providing parameter criteria using the IQuery type provided as part of the method call. Doing so allows us to find the correct Handle method when the target implements two or more handler interfaces. Otherwise, we would receive an AmbiguousMatchException.
