### PR TITLE
QueryHandler.Handle overloading bug

### DIFF
--- a/ShortBus.Tests/Example/ConsoleWriter.cs
+++ b/ShortBus.Tests/Example/ConsoleWriter.cs
@@ -2,9 +2,14 @@
 
 namespace ShortBus.Tests.Example
 {
-    public class ConsoleWriter : ICommandHandler<PrintText>
+    public class OverloadedConsoleWriter : ICommandHandler<PrintTextA>, ICommandHandler<PrintTextB>
     {
-        public void Handle(PrintText message)
+        public void Handle(PrintTextA message)
+        {
+            Console.WriteLine(message.Format, message.Args);
+        }
+
+        public void Handle(PrintTextB message)
         {
             Console.WriteLine(message.Format, message.Args);
         }

--- a/ShortBus.Tests/Example/OverloadExample.cs
+++ b/ShortBus.Tests/Example/OverloadExample.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Diagnostics;
+using NUnit.Framework;
+using StructureMap;
+
+namespace ShortBus.Tests.Example
+{
+    [TestFixture]
+    public class OverloadExample
+    {
+        public OverloadExample()
+        {
+            ObjectFactory.Initialize(i => i.Scan(s =>
+                {
+                    s.AssemblyContainingType<IMediator>();
+                    s.TheCallingAssembly();
+                    s.WithDefaultConventions();
+                    s.AddAllTypesOf((typeof (IQueryHandler<,>)));
+                    s.AddAllTypesOf(typeof (ICommandHandler<>));
+                }));
+        }
+
+        [Test]
+        public void ImplementMultipleQueryHandlers()
+        {
+            var querya = new PingA();
+            var queryb = new PingB();
+
+            var mediator = ObjectFactory.GetInstance<IMediator>();
+
+            var ponga = mediator.Request(querya);
+
+            Assert.That(ponga.Data, Is.EqualTo("PONG-A!"));
+            Assert.That(ponga.HasException(), Is.False);
+
+            var pongb = mediator.Request(queryb);
+
+            Assert.That(pongb.Data, Is.EqualTo("PONG-B!"));
+            Assert.That(pongb.HasException(), Is.False);
+        }
+
+        [Test]
+        public void Send()
+        {
+            var commandA = new PrintTextA
+                {
+                    Format = "This is a {0} message for {1}",
+                    Args = new object[] {"text", "A"}
+                };
+
+            var commandB = new PrintTextB
+            {
+                Format = "This is a {0} message for {1}",
+                Args = new object[] { "text", "B" }
+            };
+
+            var mediator = ObjectFactory.GetInstance<IMediator>();
+
+            var responseA = mediator.Send(commandA);
+
+            Assert.That(responseA.HasException(), Is.False);
+
+            var responseB = mediator.Send(commandB);
+
+            Assert.That(responseB.HasException(), Is.False);
+        }
+    }
+}

--- a/ShortBus.Tests/Example/OverloadedConsoleWriter.cs
+++ b/ShortBus.Tests/Example/OverloadedConsoleWriter.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ShortBus.Tests.Example
+{
+    public class ConsoleWriter : ICommandHandler<PrintText>
+    {
+        public void Handle(PrintText message)
+        {
+            Console.WriteLine(message.Format, message.Args);
+        }
+    }
+}

--- a/ShortBus.Tests/Example/Ping.cs
+++ b/ShortBus.Tests/Example/Ping.cs
@@ -2,4 +2,7 @@
 {
     public class Ping : IQuery<string> {}
     public class PingALing : Ping {}
+
+    public class PingA : IQuery<string> { }
+    public class PingB : IQuery<string> { }
 }

--- a/ShortBus.Tests/Example/Pong.cs
+++ b/ShortBus.Tests/Example/Pong.cs
@@ -7,4 +7,17 @@
             return "PONG!";
         }
     }
+
+    public class PongAB : IQueryHandler<PingA, string>, IQueryHandler<PingB, string>
+    {
+        public string Handle(PingA request)
+        {
+            return "PONG-A!";
+        }
+
+        public string Handle(PingB request)
+        {
+            return "PONG-B!";
+        }
+    }
 }

--- a/ShortBus.Tests/Example/PrintText.cs
+++ b/ShortBus.Tests/Example/PrintText.cs
@@ -16,4 +16,16 @@ namespace ShortBus.Tests.Example
             set { _format = value; }
         }
     }
+
+    public class PrintTextA
+    {
+        public virtual string Format { get; set; }
+        public virtual object[] Args { get; set; }
+    }
+
+    public class PrintTextB
+    {
+        public virtual string Format { get; set; }
+        public virtual object[] Args { get; set; }
+    }
 }

--- a/ShortBus.Tests/ShortBus.Tests.csproj
+++ b/ShortBus.Tests/ShortBus.Tests.csproj
@@ -57,6 +57,8 @@
     <Compile Include="Example\AsyncExample.cs" />
     <Compile Include="Example\BasicExample.cs" />
     <Compile Include="Example\ConsoleWriter.cs" />
+    <Compile Include="Example\OverloadedConsoleWriter.cs" />
+    <Compile Include="Example\OverloadExample.cs" />
     <Compile Include="Example\Ping.cs" />
     <Compile Include="Example\Pong.cs" />
     <Compile Include="Example\PrintText.cs" />

--- a/ShortBus/Mediator.cs
+++ b/ShortBus/Mediator.cs
@@ -3,11 +3,15 @@ namespace ShortBus
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
     using System.Threading.Tasks;
     using StructureMap;
 
     public class Mediator : IMediator
     {
+        private static readonly IDictionary<Type, MethodInfo> _methodInfoCache = new Dictionary<Type, MethodInfo>();
+        private static readonly IDictionary<Type, MethodInfo> _methodInfoAsyncCache = new Dictionary<Type, MethodInfo>(); 
+
         readonly IContainer _container;
 
         public Mediator(IContainer container)
@@ -107,33 +111,44 @@ namespace ShortBus
 
         static TResponseData ProcessQueryWithHandler<TResponseData>(IQuery<TResponseData> query, object handler)
         {
-            var method = (from m in handler.GetType().GetMethods()
-                          let parameters = m.GetParameters()
-                          let returnType = m.ReturnType
-                          where m.Name == "Handle" &&
-                                parameters.Length == 1 &&
-                                parameters[0].ParameterType.IsInstanceOfType(query) &&
-                                returnType == typeof (TResponseData)
-                          select m).First();
+            Type queryType = query.GetType();
+            if (!_methodInfoCache.ContainsKey(queryType))
+            {
+                var method = (from m in handler.GetType().GetMethods()
+                              let parameters = m.GetParameters()
+                              let returnType = m.ReturnType
+                              where m.Name == "Handle" &&
+                                    parameters.Length == 1 &&
+                                    parameters[0].ParameterType.IsInstanceOfType(query) &&
+                                    returnType == typeof(TResponseData)
+                              select m).First();
 
+                _methodInfoCache.Add(queryType, method);
+            }
 
-            return (TResponseData) method.Invoke(handler, new object[] {query});
+            return (TResponseData)_methodInfoCache[queryType].Invoke(handler, new object[] { query });
         }
 
         static Task<TResponseData> ProcessQueryWithHandlerAsync<TResponseData>(IAsyncQuery<TResponseData> query, object handler)
         {
-            var taskReturnType = typeof (Task<>).MakeGenericType(typeof (TResponseData));
+            Type queryType = query.GetType();
+            if (!_methodInfoAsyncCache.ContainsKey(queryType))
+            {
+                var taskReturnType = typeof (Task<>).MakeGenericType(typeof (TResponseData));
 
-            var method = (from m in handler.GetType().GetMethods()
-                          let parameters = m.GetParameters()
-                          let returnType = m.ReturnType
-                          where m.Name == "HandleAsync" &&
-                                parameters.Length == 1 &&
-                                parameters[0].ParameterType.IsInstanceOfType(query) &&
-                                returnType == taskReturnType
-                          select m).First();
+                var method = (from m in handler.GetType().GetMethods()
+                              let parameters = m.GetParameters()
+                              let returnType = m.ReturnType
+                              where m.Name == "HandleAsync" &&
+                                    parameters.Length == 1 &&
+                                    parameters[0].ParameterType.IsInstanceOfType(query) &&
+                                    returnType == taskReturnType
+                              select m).First();
 
-            return (Task<TResponseData>) method.Invoke(handler, new object[] { query });
+                _methodInfoAsyncCache.Add(queryType, method);
+            }
+
+            return (Task<TResponseData>)_methodInfoAsyncCache[queryType].Invoke(handler, new object[] { query });
         }
 
         object GetHandler<TResponseData>(IQuery<TResponseData> query)


### PR DESCRIPTION
I encountered an issue where I had a class which needed to implement multiple versions IQueryHandler. The current implementation throws an AmbiguousMatchException when the GetMethod("Handle") is called in Mediator because there were multiple overloads of the Handle method. 

Because the Mediator Send method does not use reflection, this issue does not exist when a class implements multiple versions of ICommandHandler.

After I made the change for allowing overloading the Handle method, I noticed the results from the Perf test were approximately twice as slow. To remedy this, I added logic for caching the MethodInfo instances the first time they are retrieved. The Perf test results were comparable to master after adding the caching, albeit a hair slower.
