### PR TITLE
various container implementations which resolves #2

### DIFF
--- a/ShortBus.Autofac.nuspec
+++ b/ShortBus.Autofac.nuspec
@@ -7,17 +7,18 @@
     <licenseUrl>https://github.com/mhinze/ShortBus/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>https://github.com/mhinze/ShortBus</projectUrl>
     <iconUrl>https://github.com/mhinze/ShortBus/raw/master/sb.jpg</iconUrl>
-    <id>ShortBus</id>
-    <title>ShortBus</title>
+    <id>ShortBus.Autofac</id>
+    <title>ShortBus.Autofac</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>ShortBus is an in-process mediator with low-friction API</description>
     <summary>ShortBus is an in-process mediator with low-friction API</summary>
     <copyright>Copyright Matt Hinze 2013</copyright>
     <dependencies>
         <dependency id="ShortBus.Markers" version="2.2.39" />
+		<dependency id="ShortBus" version="2.2.39" />
     </dependencies>
   </metadata>
     <files>
-        <file src="ShortBus\bin\Release\ShortBus.dll" target="lib"/>
+        <file src="ShortBus.Autofac\bin\Release\ShortBus.Autofac.dll" target="lib"/>
     </files>
 </package>

--- a/ShortBus.Autofac/AutofacDependencyResolver.cs
+++ b/ShortBus.Autofac/AutofacDependencyResolver.cs
@@ -1,0 +1,27 @@
+using Autofac;
+
+namespace ShortBus.Autofac
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class AutofacDependencyResolver : IDependencyResolver
+    {
+        readonly IContainer _container;
+
+        public AutofacDependencyResolver(IContainer container)
+        {
+            _container = container;
+        }
+
+        public object GetInstance(Type type)
+        {
+            return _container.Resolve(type);
+        }
+
+        public IEnumerable<T> GetInstances<T>()
+        {
+            return _container.Resolve<IEnumerable<T>>();
+        }
+    }
+}

--- a/ShortBus.Autofac/Properties/AssemblyInfo.cs
+++ b/ShortBus.Autofac/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ShortBus.Autofac")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ShortBus.Autofac")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d043983c-3a10-4b36-8739-980f32c93401")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ShortBus.Autofac/ShortBus.Autofac.csproj
+++ b/ShortBus.Autofac/ShortBus.Autofac.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0A3CE491-085A-460C-BEE8-D577DFB0244D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ShortBus.Autofac</RootNamespace>
+    <AssemblyName>ShortBus.Autofac</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Autofac">
+      <HintPath>..\packages\Autofac.3.1.5\lib\net40\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="AutofacDependencyResolver.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ShortBus\ShortBus.csproj">
+      <Project>{50078B66-DBAC-4273-8DD0-970176B2FE2B}</Project>
+      <Name>ShortBus</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ShortBus.Autofac/packages.config
+++ b/ShortBus.Autofac/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Autofac" version="3.1.5" targetFramework="net45" />
+</packages>

--- a/ShortBus.Ninject.nuspec
+++ b/ShortBus.Ninject.nuspec
@@ -7,17 +7,18 @@
     <licenseUrl>https://github.com/mhinze/ShortBus/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>https://github.com/mhinze/ShortBus</projectUrl>
     <iconUrl>https://github.com/mhinze/ShortBus/raw/master/sb.jpg</iconUrl>
-    <id>ShortBus</id>
-    <title>ShortBus</title>
+    <id>ShortBus.Ninject</id>
+    <title>ShortBus.Ninject</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>ShortBus is an in-process mediator with low-friction API</description>
     <summary>ShortBus is an in-process mediator with low-friction API</summary>
     <copyright>Copyright Matt Hinze 2013</copyright>
     <dependencies>
         <dependency id="ShortBus.Markers" version="2.2.39" />
+		<dependency id="ShortBus" version="2.2.39" />
     </dependencies>
   </metadata>
     <files>
-        <file src="ShortBus\bin\Release\ShortBus.dll" target="lib"/>
+        <file src="ShortBus.Ninject\bin\Release\ShortBus.Ninject.dll" target="lib"/>
     </files>
 </package>

--- a/ShortBus.Ninject/NinjectDependencyResolver.cs
+++ b/ShortBus.Ninject/NinjectDependencyResolver.cs
@@ -1,0 +1,27 @@
+﻿using Ninject;
+
+namespace ShortBus.Ninject
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class NinjectDependencyResolver : IDependencyResolver
+    {
+        readonly IKernel _container;
+
+        public NinjectDependencyResolver(IKernel container)
+        {
+            _container = container;
+        }
+
+        public object GetInstance(Type type)
+        {
+            return _container.Get(type);
+        }
+
+        public IEnumerable<T> GetInstances<T>()
+        {
+            return _container.GetAll<T>();
+        }
+    }
+}

--- a/ShortBus.Ninject/Properties/AssemblyInfo.cs
+++ b/ShortBus.Ninject/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ShortBus.Ninject")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ShortBus.Ninject")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("44900dbc-c446-453c-966a-d985b47cecb7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ShortBus.Ninject/ShortBus.Ninject.csproj
+++ b/ShortBus.Ninject/ShortBus.Ninject.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{26835F98-3898-4467-9999-2FC2DFC50370}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ShortBus.Ninject</RootNamespace>
+    <AssemblyName>ShortBus.Ninject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Ninject">
+      <HintPath>..\packages\Ninject.3.0.1.10\lib\net45-full\Ninject.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NinjectDependencyResolver.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ShortBus\ShortBus.csproj">
+      <Project>{50078B66-DBAC-4273-8DD0-970176B2FE2B}</Project>
+      <Name>ShortBus</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ShortBus.Ninject/packages.config
+++ b/ShortBus.Ninject/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Ninject" version="3.0.1.10" targetFramework="net45" />
+</packages>

--- a/ShortBus.StructureMap.nuspec
+++ b/ShortBus.StructureMap.nuspec
@@ -7,17 +7,18 @@
     <licenseUrl>https://github.com/mhinze/ShortBus/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>https://github.com/mhinze/ShortBus</projectUrl>
     <iconUrl>https://github.com/mhinze/ShortBus/raw/master/sb.jpg</iconUrl>
-    <id>ShortBus</id>
-    <title>ShortBus</title>
+    <id>ShortBus.StructureMap</id>
+    <title>ShortBus.StructureMap</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>ShortBus is an in-process mediator with low-friction API</description>
     <summary>ShortBus is an in-process mediator with low-friction API</summary>
     <copyright>Copyright Matt Hinze 2013</copyright>
     <dependencies>
         <dependency id="ShortBus.Markers" version="2.2.39" />
+		<dependency id="ShortBus" version="2.2.39" />
     </dependencies>
   </metadata>
     <files>
-        <file src="ShortBus\bin\Release\ShortBus.dll" target="lib"/>
+        <file src="ShortBus.StructureMap\bin\Release\ShortBus.StructureMap.dll" target="lib"/>
     </files>
 </package>

--- a/ShortBus.StructureMap/Properties/AssemblyInfo.cs
+++ b/ShortBus.StructureMap/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ShortBus.StructureMap")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ShortBus.StructureMap")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("862899e5-67df-49d9-9102-a6c0ac5ad715")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ShortBus.StructureMap/ShortBus.StructureMap.csproj
+++ b/ShortBus.StructureMap/ShortBus.StructureMap.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8250FBB2-1372-4F46-916A-00F094B04F37}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ShortBus.StructureMap</RootNamespace>
+    <AssemblyName>ShortBus.StructureMap</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="StructureMap">
+      <HintPath>..\packages\structuremap.2.6.3\lib\StructureMap.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StructureMapDependencyResolver.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ShortBus\ShortBus.csproj">
+      <Project>{50078B66-DBAC-4273-8DD0-970176B2FE2B}</Project>
+      <Name>ShortBus</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ShortBus.StructureMap/StructureMapDependencyResolver.cs
+++ b/ShortBus.StructureMap/StructureMapDependencyResolver.cs
@@ -1,0 +1,27 @@
+using StructureMap;
+
+namespace ShortBus.StructureMap
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class StructureMapDependencyResolver : IDependencyResolver
+    {
+        readonly IContainer _container;
+
+        public StructureMapDependencyResolver(IContainer container)
+        {
+            _container = container;
+        }
+
+        public object GetInstance(Type type)
+        {
+            return _container.GetInstance(type);
+        }
+
+        public IEnumerable<T> GetInstances<T>()
+        {
+            return _container.GetAllInstances<T>();
+        }
+    }
+}

--- a/ShortBus.StructureMap/packages.config
+++ b/ShortBus.StructureMap/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="structuremap" version="2.6.3" targetFramework="net45" />
+</packages>

--- a/ShortBus.Tests/Containers/ContainerTests.cs
+++ b/ShortBus.Tests/Containers/ContainerTests.cs
@@ -1,0 +1,138 @@
+﻿using System.Linq;
+using Autofac;
+using Castle.MicroKernel.Registration;
+using Castle.Windsor;
+using Microsoft.Practices.Unity;
+using NUnit.Framework;
+using Ninject;
+using ShortBus.Autofac;
+using ShortBus.Ninject;
+using ShortBus.StructureMap;
+using ShortBus.Unity;
+using ShortBus.Windsor;
+using StructureMap;
+
+namespace ShortBus.Tests.Containers
+{
+    [TestFixture]
+    public class ContainerTests
+    {
+        public ContainerTests()
+        {
+        }
+
+        [Test]
+        public void AutofacResolveSingleInstance()
+        {
+            var builder = new ContainerBuilder();
+            var registerSingle = new RegisterSingle();
+            var multipleRegistrations = new[] { new RegisterMultiple(), new RegisterMultiple() };
+            builder.RegisterInstance(registerSingle);
+            builder.RegisterInstance(multipleRegistrations[0]);
+            builder.RegisterInstance(multipleRegistrations[1]);
+
+            var resolver = new AutofacDependencyResolver(builder.Build());
+
+            var resolvedSingle = (RegisterSingle) resolver.GetInstance(typeof (RegisterSingle));
+            var resolvedMultiple = resolver.GetInstances<RegisterMultiple>().ToArray();
+            Assert.That(resolvedSingle, Is.EqualTo(registerSingle));
+            Assert.That(resolvedMultiple.Count(), Is.EqualTo(2));
+            Assert.That(resolvedMultiple.Contains(multipleRegistrations[0]));
+            Assert.That(resolvedMultiple.Contains(multipleRegistrations[1]));
+        }
+
+        [Test]
+        public void NinjectResolveSingleInstance()
+        {
+            var kernel = new StandardKernel();
+            var registerSingle = new RegisterSingle();
+            var multipleRegistrations = new[] { new RegisterMultiple(), new RegisterMultiple() };
+            kernel.Bind<RegisterSingle>().ToConstant(registerSingle);
+            kernel.Bind<RegisterMultiple>().ToConstant(multipleRegistrations[0]);
+            kernel.Bind<RegisterMultiple>().ToConstant(multipleRegistrations[1]);
+
+            var resolver = new NinjectDependencyResolver(kernel);
+
+            var resolvedSingle = (RegisterSingle)resolver.GetInstance(typeof(RegisterSingle));
+            var resolvedMultiple = resolver.GetInstances<RegisterMultiple>().ToArray();
+            Assert.That(resolvedSingle, Is.EqualTo(registerSingle));
+            Assert.That(resolvedMultiple.Count(), Is.EqualTo(2));
+            Assert.That(resolvedMultiple.Contains(multipleRegistrations[0]));
+            Assert.That(resolvedMultiple.Contains(multipleRegistrations[1]));
+        }
+
+        [Test]
+        public void StructureMapResolveSingleInstance()
+        {
+            var registerSingle = new RegisterSingle();
+            var multipleRegistrations = new[] { new RegisterMultiple(), new RegisterMultiple() };
+
+            ObjectFactory.Initialize(i =>
+            {
+                i.Register(registerSingle);
+                i.Register(multipleRegistrations[0]);
+                i.Register(multipleRegistrations[1]);
+            });
+
+            var resolver = new StructureMapDependencyResolver(ObjectFactory.Container);
+
+            var resolvedSingle = (RegisterSingle)resolver.GetInstance(typeof(RegisterSingle));
+            var resolvedMultiple = resolver.GetInstances<RegisterMultiple>().ToArray();
+            Assert.That(resolvedSingle, Is.EqualTo(registerSingle));
+            Assert.That(resolvedMultiple.Count(), Is.EqualTo(2));
+            Assert.That(resolvedMultiple.Contains(multipleRegistrations[0]));
+            Assert.That(resolvedMultiple.Contains(multipleRegistrations[1]));
+        }
+
+        [Test]
+        public void UnityResolveSingleInstance()
+        {
+            var container = new UnityContainer();
+            var registerSingle = new RegisterSingle();
+            var multipleRegistrations = new[] { new RegisterMultiple(), new RegisterMultiple() };
+            container.RegisterInstance(registerSingle);
+            //unity requires a name when registering multiple instances of the same type or nothing will be resolved.
+            container.RegisterInstance("instance1", multipleRegistrations[0]);
+            container.RegisterInstance("instance2", multipleRegistrations[1]);
+
+            var resolver = new UnityDependencyResolver(container);
+
+            var resolvedSingle = (RegisterSingle)resolver.GetInstance(typeof(RegisterSingle));
+            var resolvedMultiple = resolver.GetInstances<RegisterMultiple>().ToArray();
+            Assert.That(resolvedSingle, Is.EqualTo(registerSingle));
+            Assert.That(resolvedMultiple.Count(), Is.EqualTo(2));
+            Assert.That(resolvedMultiple.Contains(multipleRegistrations[0]));
+            Assert.That(resolvedMultiple.Contains(multipleRegistrations[1]));
+        }
+
+        [Test]
+        public void WindsorResolveSingleInstance()
+        {
+            var container = new WindsorContainer();
+            var registerSingle = new RegisterSingle();
+            var multipleRegistrations = new[] { new RegisterMultiple(), new RegisterMultiple() };
+            //unity requires a name when registering multiple instances of the same type or nothing will be resolved.
+            container.Register(Component.For<RegisterSingle>().Instance(registerSingle));
+            container.Register(Component.For<RegisterMultiple>().Instance(multipleRegistrations[0]).Named("instance1"));
+            container.Register(Component.For<RegisterMultiple>().Instance(multipleRegistrations[1]).Named("instance2"));
+
+            var resolver = new WindsorDependencyResolver(container);
+
+            var resolvedSingle = (RegisterSingle)resolver.GetInstance(typeof(RegisterSingle));
+            var resolvedMultiple = resolver.GetInstances<RegisterMultiple>().ToArray();
+            Assert.That(resolvedSingle, Is.EqualTo(registerSingle));
+            Assert.That(resolvedMultiple.Count(), Is.EqualTo(2));
+            Assert.That(resolvedMultiple.Contains(multipleRegistrations[0]));
+            Assert.That(resolvedMultiple.Contains(multipleRegistrations[1]));
+        }
+
+        class RegisterSingle
+        {
+        }
+
+        class RegisterMultiple
+        {
+            
+        }
+    }
+}

--- a/ShortBus.Tests/Example/AsyncExample.cs
+++ b/ShortBus.Tests/Example/AsyncExample.cs
@@ -1,4 +1,6 @@
-﻿namespace ShortBus.Tests.Example
+﻿using StructureMap;
+
+namespace ShortBus.Tests.Example
 {
     using System;
     using System.Threading;
@@ -19,6 +21,8 @@
                 s.WithDefaultConventions();
                 s.AddAllTypesOf(( typeof (IAsyncQueryHandler<,>) ));
             }));
+
+            ShortBus.DependencyResolver.SetResolver(new StructureMapDependencyResolver(ObjectFactory.Container));
 
             var query = new ExternalResourceQuery();
 

--- a/ShortBus.Tests/Example/BasicExample.cs
+++ b/ShortBus.Tests/Example/BasicExample.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using NUnit.Framework;
+using ShortBus.StructureMap;
 using StructureMap;
 
 namespace ShortBus.Tests.Example
@@ -18,6 +19,8 @@ namespace ShortBus.Tests.Example
                     s.AddAllTypesOf((typeof (IQueryHandler<,>)));
                     s.AddAllTypesOf(typeof (ICommandHandler<>));
                 }));
+
+            ShortBus.DependencyResolver.SetResolver(new StructureMapDependencyResolver(ObjectFactory.Container));
         }
 
         [Test]

--- a/ShortBus.Tests/ShortBus.Tests.csproj
+++ b/ShortBus.Tests/ShortBus.Tests.csproj
@@ -36,6 +36,24 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac">
+      <HintPath>..\packages\Autofac.3.1.5\lib\net40\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.Core">
+      <HintPath>..\packages\Castle.Core.3.2.2\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.Windsor">
+      <HintPath>..\packages\Castle.Windsor.3.2.1\lib\net45\Castle.Windsor.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity">
+      <HintPath>..\packages\Unity.3.0.1304.1\lib\Net45\Microsoft.Practices.Unity.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.Configuration">
+      <HintPath>..\packages\Unity.3.0.1304.1\lib\Net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Ninject">
+      <HintPath>..\packages\Ninject.3.0.1.10\lib\net40\Ninject.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.5.9.10348, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.5.9.10348\lib\nunit.framework.dll</HintPath>
@@ -54,6 +72,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Containers\ContainerTests.cs" />
     <Compile Include="Example\AsyncExample.cs" />
     <Compile Include="Example\BasicExample.cs" />
     <Compile Include="Example\ConsoleWriter.cs" />
@@ -69,9 +88,29 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
+    <ProjectReference Include="..\ShortBus.Autofac\ShortBus.Autofac.csproj">
+      <Project>{0A3CE491-085A-460C-BEE8-D577DFB0244D}</Project>
+      <Name>ShortBus.Autofac</Name>
+    </ProjectReference>
     <ProjectReference Include="..\ShortBus.Markers\ShortBus.Markers.csproj">
       <Project>{9ABBD382-F93A-49A9-B3C7-8D8AEB5E458D}</Project>
       <Name>ShortBus.Markers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ShortBus.Ninject\ShortBus.Ninject.csproj">
+      <Project>{26835F98-3898-4467-9999-2FC2DFC50370}</Project>
+      <Name>ShortBus.Ninject</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ShortBus.StructureMap\ShortBus.StructureMap.csproj">
+      <Project>{8250FBB2-1372-4F46-916A-00F094B04F37}</Project>
+      <Name>ShortBus.StructureMap</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ShortBus.Unity\ShortBus.Unity.csproj">
+      <Project>{E86D92BC-A5E4-4704-99DB-BBFA42A3C975}</Project>
+      <Name>ShortBus.Unity</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ShortBus.Windsor\ShortBus.Windsor.csproj">
+      <Project>{126A6105-8F0E-4489-A75B-69958A00D570}</Project>
+      <Name>ShortBus.Windsor</Name>
     </ProjectReference>
     <ProjectReference Include="..\ShortBus\ShortBus.csproj">
       <Project>{50078B66-DBAC-4273-8DD0-970176B2FE2B}</Project>

--- a/ShortBus.Tests/packages.config
+++ b/ShortBus.Tests/packages.config
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Autofac" version="3.1.5" targetFramework="net45" />
+  <package id="Benchmarque" version="0.2.0" targetFramework="net45" />
+  <package id="Castle.Core" version="3.2.2" targetFramework="net45" />
+  <package id="Ninject" version="3.0.1.10" targetFramework="net45" />
   <package id="NUnit" version="2.5.9.10348" />
   <package id="structuremap" version="2.6.3" />
+  <package id="Unity" version="3.0.1304.1" targetFramework="net45" />
 </packages>

--- a/ShortBus.Unity.nuspec
+++ b/ShortBus.Unity.nuspec
@@ -7,17 +7,18 @@
     <licenseUrl>https://github.com/mhinze/ShortBus/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>https://github.com/mhinze/ShortBus</projectUrl>
     <iconUrl>https://github.com/mhinze/ShortBus/raw/master/sb.jpg</iconUrl>
-    <id>ShortBus</id>
-    <title>ShortBus</title>
+    <id>ShortBus.Unity</id>
+    <title>ShortBus.Unity</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>ShortBus is an in-process mediator with low-friction API</description>
     <summary>ShortBus is an in-process mediator with low-friction API</summary>
     <copyright>Copyright Matt Hinze 2013</copyright>
     <dependencies>
         <dependency id="ShortBus.Markers" version="2.2.39" />
+		<dependency id="ShortBus" version="2.2.39" />
     </dependencies>
   </metadata>
     <files>
-        <file src="ShortBus\bin\Release\ShortBus.dll" target="lib"/>
+        <file src="ShortBus.Unity\bin\Release\ShortBus.Unity.dll" target="lib"/>
     </files>
 </package>

--- a/ShortBus.Unity/Properties/AssemblyInfo.cs
+++ b/ShortBus.Unity/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ShortBus.Unity")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ShortBus.Unity")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("da5dd16f-602e-4840-9d7d-78ed44a87c5a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ShortBus.Unity/ShortBus.Unity.csproj
+++ b/ShortBus.Unity/ShortBus.Unity.csproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E86D92BC-A5E4-4704-99DB-BBFA42A3C975}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ShortBus.Unity</RootNamespace>
+    <AssemblyName>ShortBus.Unity</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Practices.Unity">
+      <HintPath>..\packages\Unity.3.0.1304.1\lib\Net45\Microsoft.Practices.Unity.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.Configuration">
+      <HintPath>..\packages\Unity.3.0.1304.1\lib\Net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="UnityDependencyResolver.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ShortBus\ShortBus.csproj">
+      <Project>{50078B66-DBAC-4273-8DD0-970176B2FE2B}</Project>
+      <Name>ShortBus</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ShortBus.Unity/UnityDependencyResolver.cs
+++ b/ShortBus.Unity/UnityDependencyResolver.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Practices.Unity;
+
+namespace ShortBus.Unity
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class UnityDependencyResolver : IDependencyResolver
+    {
+        readonly IUnityContainer _container;
+
+        public UnityDependencyResolver(IUnityContainer container)
+        {
+            _container = container;
+        }
+
+        public object GetInstance(Type type)
+        {
+            return _container.Resolve(type);
+        }
+
+        public IEnumerable<T> GetInstances<T>()
+        {
+            return _container.ResolveAll<T>();
+        }
+    }
+}

--- a/ShortBus.Unity/packages.config
+++ b/ShortBus.Unity/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Unity" version="3.0.1304.1" targetFramework="net45" />
+</packages>

--- a/ShortBus.Windsor.nuspec
+++ b/ShortBus.Windsor.nuspec
@@ -7,17 +7,18 @@
     <licenseUrl>https://github.com/mhinze/ShortBus/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>https://github.com/mhinze/ShortBus</projectUrl>
     <iconUrl>https://github.com/mhinze/ShortBus/raw/master/sb.jpg</iconUrl>
-    <id>ShortBus</id>
-    <title>ShortBus</title>
+    <id>ShortBus.Windsor</id>
+    <title>ShortBus.Windsor</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>ShortBus is an in-process mediator with low-friction API</description>
     <summary>ShortBus is an in-process mediator with low-friction API</summary>
     <copyright>Copyright Matt Hinze 2013</copyright>
     <dependencies>
         <dependency id="ShortBus.Markers" version="2.2.39" />
+		<dependency id="ShortBus" version="2.2.39" />
     </dependencies>
   </metadata>
     <files>
-        <file src="ShortBus\bin\Release\ShortBus.dll" target="lib"/>
+        <file src="ShortBus.Windsor\bin\Release\ShortBus.Windsor.dll" target="lib"/>
     </files>
 </package>

--- a/ShortBus.Windsor/Properties/AssemblyInfo.cs
+++ b/ShortBus.Windsor/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ShortBus.Windsor")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ShortBus.Windsor")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ce241a26-dc71-4fe6-b8a6-ce73f27d4c95")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ShortBus.Windsor/ShortBus.Windsor.csproj
+++ b/ShortBus.Windsor/ShortBus.Windsor.csproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{126A6105-8F0E-4489-A75B-69958A00D570}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ShortBus.Windsor</RootNamespace>
+    <AssemblyName>ShortBus.Windsor</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Castle.Core">
+      <HintPath>..\packages\Castle.Core.3.2.2\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.Windsor">
+      <HintPath>..\packages\Castle.Windsor.3.2.1\lib\net45\Castle.Windsor.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="WindsorDependencyResolver.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ShortBus\ShortBus.csproj">
+      <Project>{50078B66-DBAC-4273-8DD0-970176B2FE2B}</Project>
+      <Name>ShortBus</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ShortBus.Windsor/WindsorDependencyResolver.cs
+++ b/ShortBus.Windsor/WindsorDependencyResolver.cs
@@ -1,0 +1,27 @@
+﻿using Castle.Windsor;
+
+namespace ShortBus.Windsor
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class WindsorDependencyResolver : IDependencyResolver
+    {
+        readonly IWindsorContainer _container;
+
+        public WindsorDependencyResolver(IWindsorContainer container)
+        {
+            _container = container;
+        }
+
+        public object GetInstance(Type type)
+        {
+            return _container.Resolve(type);
+        }
+
+        public IEnumerable<T> GetInstances<T>()
+        {
+            return _container.ResolveAll<T>();
+        }
+    }
+}

--- a/ShortBus.Windsor/packages.config
+++ b/ShortBus.Windsor/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="3.2.2" targetFramework="net45" />
+  <package id="Castle.Windsor" version="3.2.1" targetFramework="net45" />
+</packages>

--- a/ShortBus.sln
+++ b/ShortBus.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShortBus", "ShortBus\ShortBus.csproj", "{50078B66-DBAC-4273-8DD0-970176B2FE2B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShortBus.Tests", "ShortBus.Tests\ShortBus.Tests.csproj", "{9EA21775-A0CF-4F6D-82A6-CDFB1817DB3A}"
@@ -18,6 +18,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Readme", "Readme", "{A07561
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShortBus.Markers", "ShortBus.Markers\ShortBus.Markers.csproj", "{9ABBD382-F93A-49A9-B3C7-8D8AEB5E458D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShortBus.StructureMap", "ShortBus.StructureMap\ShortBus.StructureMap.csproj", "{8250FBB2-1372-4F46-916A-00F094B04F37}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShortBus.Autofac", "ShortBus.Autofac\ShortBus.Autofac.csproj", "{0A3CE491-085A-460C-BEE8-D577DFB0244D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShortBus.Windsor", "ShortBus.Windsor\ShortBus.Windsor.csproj", "{126A6105-8F0E-4489-A75B-69958A00D570}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Containers", "Containers", "{8B88A450-D492-4839-A18D-C100AB63618D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShortBus.Ninject", "ShortBus.Ninject\ShortBus.Ninject.csproj", "{26835F98-3898-4467-9999-2FC2DFC50370}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShortBus.Unity", "ShortBus.Unity\ShortBus.Unity.csproj", "{E86D92BC-A5E4-4704-99DB-BBFA42A3C975}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,8 +49,35 @@ Global
 		{9ABBD382-F93A-49A9-B3C7-8D8AEB5E458D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9ABBD382-F93A-49A9-B3C7-8D8AEB5E458D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9ABBD382-F93A-49A9-B3C7-8D8AEB5E458D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8250FBB2-1372-4F46-916A-00F094B04F37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8250FBB2-1372-4F46-916A-00F094B04F37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8250FBB2-1372-4F46-916A-00F094B04F37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8250FBB2-1372-4F46-916A-00F094B04F37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A3CE491-085A-460C-BEE8-D577DFB0244D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A3CE491-085A-460C-BEE8-D577DFB0244D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A3CE491-085A-460C-BEE8-D577DFB0244D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A3CE491-085A-460C-BEE8-D577DFB0244D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{126A6105-8F0E-4489-A75B-69958A00D570}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{126A6105-8F0E-4489-A75B-69958A00D570}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{126A6105-8F0E-4489-A75B-69958A00D570}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{126A6105-8F0E-4489-A75B-69958A00D570}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26835F98-3898-4467-9999-2FC2DFC50370}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26835F98-3898-4467-9999-2FC2DFC50370}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26835F98-3898-4467-9999-2FC2DFC50370}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26835F98-3898-4467-9999-2FC2DFC50370}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E86D92BC-A5E4-4704-99DB-BBFA42A3C975}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E86D92BC-A5E4-4704-99DB-BBFA42A3C975}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E86D92BC-A5E4-4704-99DB-BBFA42A3C975}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E86D92BC-A5E4-4704-99DB-BBFA42A3C975}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0A3CE491-085A-460C-BEE8-D577DFB0244D} = {8B88A450-D492-4839-A18D-C100AB63618D}
+		{126A6105-8F0E-4489-A75B-69958A00D570} = {8B88A450-D492-4839-A18D-C100AB63618D}
+		{8250FBB2-1372-4F46-916A-00F094B04F37} = {8B88A450-D492-4839-A18D-C100AB63618D}
+		{26835F98-3898-4467-9999-2FC2DFC50370} = {8B88A450-D492-4839-A18D-C100AB63618D}
+		{E86D92BC-A5E4-4704-99DB-BBFA42A3C975} = {8B88A450-D492-4839-A18D-C100AB63618D}
 	EndGlobalSection
 EndGlobal

--- a/ShortBus/DependencyResolver.cs
+++ b/ShortBus/DependencyResolver.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ShortBus
+{
+    public interface IDependencyResolver
+    {
+        object GetInstance(Type type);
+        IEnumerable<T> GetInstances<T>();
+    }
+
+    public static class DependencyResolver
+    {
+        public static IDependencyResolver Current;
+
+        public static void SetResolver(IDependencyResolver resolver)
+        {
+            Current = resolver;
+        }
+
+        public static void SetResolver(Func<Type, object> getInstance, Func<Type, IEnumerable<object>> getInstances)
+        {
+            Current = new DelegateDependencyResolver(getInstance, getInstances);
+        }
+
+        private class DelegateDependencyResolver : IDependencyResolver
+        {
+            private readonly Func<Type, object> _getInstance;
+            private readonly Func<Type, IEnumerable<object>> _getInstances;
+
+            public DelegateDependencyResolver(Func<Type, object> getInstance, Func<Type, IEnumerable<object>> getInstances)
+            {
+                _getInstance = getInstance;
+                _getInstances = getInstances;
+            }
+
+            public object GetInstance(Type type)
+            {
+                return _getInstance(type);
+            }
+
+            public IEnumerable<T> GetInstances<T>()
+            {
+                return _getInstances(typeof (T)).OfType<T>();
+            }
+        }
+    }
+}

--- a/ShortBus/Mediator.cs
+++ b/ShortBus/Mediator.cs
@@ -5,17 +5,9 @@ namespace ShortBus
     using System.Linq;
     using System.Reflection;
     using System.Threading.Tasks;
-    using StructureMap;
 
     public class Mediator : IMediator
     {
-        readonly IContainer _container;
-
-        public Mediator(IContainer container)
-        {
-            _container = container;
-        }
-
         public virtual Response<TResponseData> Request<TResponseData>(IQuery<TResponseData> query)
         {
             var response = new Response<TResponseData>();
@@ -54,7 +46,7 @@ namespace ShortBus
 
         public virtual Response Send<TMessage>(TMessage message)
         {
-            var allInstances = _container.GetAllInstances<ICommandHandler<TMessage>>();
+            var allInstances = DependencyResolver.Current.GetInstances<ICommandHandler<TMessage>>();
 
             var response = new Response();
             List<Exception> exceptions = null;
@@ -74,7 +66,7 @@ namespace ShortBus
 
         public async Task<Response> SendAsync<TMessage>(TMessage message)
         {
-            var handlers = _container.GetAllInstances<IAsyncCommandHandler<TMessage>>();
+            var handlers = DependencyResolver.Current.GetInstances<IAsyncCommandHandler<TMessage>>();
 
             return await Task
                 .WhenAll(handlers.Select(x => sendAsync(x, message)))
@@ -129,14 +121,14 @@ namespace ShortBus
         object GetHandler<TResponseData>(IQuery<TResponseData> query)
         {
             var handlerType = typeof (IQueryHandler<,>).MakeGenericType(query.GetType(), typeof (TResponseData));
-            var handler = _container.GetInstance(handlerType);
+            var handler = DependencyResolver.Current.GetInstance(handlerType);
             return handler;
         }
 
         object GetAsyncHandler<TResponseData>(IAsyncQuery<TResponseData> query)
         {
             var handlerType = typeof (IAsyncQueryHandler<,>).MakeGenericType(query.GetType(), typeof (TResponseData));
-            var handler = _container.GetInstance(handlerType);
+            var handler = DependencyResolver.Current.GetInstance(handlerType);
             return handler;
         }
     }

--- a/ShortBus/ShortBus.csproj
+++ b/ShortBus/ShortBus.csproj
@@ -36,20 +36,18 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StructureMap">
-      <HintPath>..\packages\structuremap.2.6.3\lib\StructureMap.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DependencyResolver.cs" />
     <Compile Include="IAsyncCommandHandler.cs" />
     <Compile Include="IAsyncQueryHandler.cs" />
-    <Compile Include="Mediator.cs" />
     <Compile Include="IMediator.cs" />
     <Compile Include="ICommandHandler.cs" />
     <Compile Include="IQueryHandler.cs" />
+    <Compile Include="Mediator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Response.cs" />
   </ItemGroup>

--- a/ShortBus/packages.config
+++ b/ShortBus/packages.config
@@ -1,4 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="structuremap" version="2.6.3" />
 </packages>


### PR DESCRIPTION
Removed the direct dependency on StructureMap.
Allow setting DependencyResolver using Funcs.
Added IDependencyResolver implementations for Autofac, Ninject, Unity, Windsor and of course StructureMap.
Nuspec files for the new container implementations
