### PR TITLE
significant redesign of command handlers

### DIFF
--- a/ShortBus.Autofac/AutofacDependencyResolver.cs
+++ b/ShortBus.Autofac/AutofacDependencyResolver.cs
@@ -1,9 +1,7 @@
-using Autofac;
-
 namespace ShortBus.Autofac
 {
     using System;
-    using System.Collections.Generic;
+    using global::Autofac;
 
     public class AutofacDependencyResolver : IDependencyResolver
     {
@@ -17,11 +15,6 @@ namespace ShortBus.Autofac
         public object GetInstance(Type type)
         {
             return _container.Resolve(type);
-        }
-
-        public IEnumerable<T> GetInstances<T>()
-        {
-            return _container.Resolve<IEnumerable<T>>();
         }
     }
 }

--- a/ShortBus.Markers/IAsyncCommand.cs
+++ b/ShortBus.Markers/IAsyncCommand.cs
@@ -1,4 +1,6 @@
 namespace ShortBus
 {
-    public interface IAsyncCommand {}
+    public interface IAsyncCommand : IAsyncCommand<UnitType> { }
+
+    public interface IAsyncCommand<TResult> { }
 }

--- a/ShortBus.Markers/ICommand.cs
+++ b/ShortBus.Markers/ICommand.cs
@@ -1,4 +1,6 @@
 namespace ShortBus
 {
-    public interface ICommand {}
+    public interface ICommand : ICommand<UnitType> { }
+
+    public interface ICommand<TResult> { }
 }

--- a/ShortBus.Markers/ShortBus.Markers.csproj
+++ b/ShortBus.Markers/ShortBus.Markers.csproj
@@ -48,6 +48,7 @@
     <Compile Include="ICommand.cs" />
     <Compile Include="IQuery.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnitType.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ShortBus.Markers/UnitType.cs
+++ b/ShortBus.Markers/UnitType.cs
@@ -1,0 +1,9 @@
+namespace ShortBus
+{
+    public sealed class UnitType
+    {
+        public static readonly UnitType Default = new UnitType();
+
+        UnitType() { }
+    }
+}

--- a/ShortBus.Ninject/NinjectDependencyResolver.cs
+++ b/ShortBus.Ninject/NinjectDependencyResolver.cs
@@ -1,9 +1,7 @@
-﻿using Ninject;
-
-namespace ShortBus.Ninject
+﻿namespace ShortBus.Ninject
 {
     using System;
-    using System.Collections.Generic;
+    using global::Ninject;
 
     public class NinjectDependencyResolver : IDependencyResolver
     {
@@ -17,11 +15,6 @@ namespace ShortBus.Ninject
         public object GetInstance(Type type)
         {
             return _container.Get(type);
-        }
-
-        public IEnumerable<T> GetInstances<T>()
-        {
-            return _container.GetAll<T>();
         }
     }
 }

--- a/ShortBus.StructureMap/StructureMapDependencyResolver.cs
+++ b/ShortBus.StructureMap/StructureMapDependencyResolver.cs
@@ -1,9 +1,7 @@
-using StructureMap;
-
 namespace ShortBus.StructureMap
 {
     using System;
-    using System.Collections.Generic;
+    using global::StructureMap;
 
     public class StructureMapDependencyResolver : IDependencyResolver
     {
@@ -17,11 +15,6 @@ namespace ShortBus.StructureMap
         public object GetInstance(Type type)
         {
             return _container.GetInstance(type);
-        }
-
-        public IEnumerable<T> GetInstances<T>()
-        {
-            return _container.GetAllInstances<T>();
         }
     }
 }

--- a/ShortBus.Tests/Containers/ContainerTests.cs
+++ b/ShortBus.Tests/Containers/ContainerTests.cs
@@ -1,138 +1,93 @@
-﻿using System.Linq;
-using Autofac;
-using Castle.MicroKernel.Registration;
-using Castle.Windsor;
-using Microsoft.Practices.Unity;
-using NUnit.Framework;
-using Ninject;
-using ShortBus.Autofac;
-using ShortBus.Ninject;
-using ShortBus.StructureMap;
-using ShortBus.Unity;
-using ShortBus.Windsor;
-using StructureMap;
-
-namespace ShortBus.Tests.Containers
+﻿namespace ShortBus.Tests.Containers
 {
+    using Autofac;
+    using Castle.MicroKernel.Registration;
+    using Castle.Windsor;
+    using global::Autofac;
+    using global::Ninject;
+    using global::StructureMap;
+    using Microsoft.Practices.Unity;
+    using Ninject;
+    using NUnit.Framework;
+    using StructureMap;
+    using Unity;
+    using Windsor;
+
     [TestFixture]
     public class ContainerTests
     {
-        public ContainerTests()
-        {
-        }
+        public ContainerTests() { }
+
+        class Registered { }
 
         [Test]
         public void AutofacResolveSingleInstance()
         {
             var builder = new ContainerBuilder();
-            var registerSingle = new RegisterSingle();
-            var multipleRegistrations = new[] { new RegisterMultiple(), new RegisterMultiple() };
-            builder.RegisterInstance(registerSingle);
-            builder.RegisterInstance(multipleRegistrations[0]);
-            builder.RegisterInstance(multipleRegistrations[1]);
+            var registered = new Registered();
+            builder.RegisterInstance(registered);
 
             var resolver = new AutofacDependencyResolver(builder.Build());
 
-            var resolvedSingle = (RegisterSingle) resolver.GetInstance(typeof (RegisterSingle));
-            var resolvedMultiple = resolver.GetInstances<RegisterMultiple>().ToArray();
-            Assert.That(resolvedSingle, Is.EqualTo(registerSingle));
-            Assert.That(resolvedMultiple.Count(), Is.EqualTo(2));
-            Assert.That(resolvedMultiple.Contains(multipleRegistrations[0]));
-            Assert.That(resolvedMultiple.Contains(multipleRegistrations[1]));
+            var resolved = (Registered) resolver.GetInstance(typeof (Registered));
+
+            Assert.That(resolved, Is.EqualTo(registered));
         }
 
         [Test]
         public void NinjectResolveSingleInstance()
         {
             var kernel = new StandardKernel();
-            var registerSingle = new RegisterSingle();
-            var multipleRegistrations = new[] { new RegisterMultiple(), new RegisterMultiple() };
-            kernel.Bind<RegisterSingle>().ToConstant(registerSingle);
-            kernel.Bind<RegisterMultiple>().ToConstant(multipleRegistrations[0]);
-            kernel.Bind<RegisterMultiple>().ToConstant(multipleRegistrations[1]);
+            var registered = new Registered();
+            kernel.Bind<Registered>().ToConstant(registered);
 
             var resolver = new NinjectDependencyResolver(kernel);
 
-            var resolvedSingle = (RegisterSingle)resolver.GetInstance(typeof(RegisterSingle));
-            var resolvedMultiple = resolver.GetInstances<RegisterMultiple>().ToArray();
-            Assert.That(resolvedSingle, Is.EqualTo(registerSingle));
-            Assert.That(resolvedMultiple.Count(), Is.EqualTo(2));
-            Assert.That(resolvedMultiple.Contains(multipleRegistrations[0]));
-            Assert.That(resolvedMultiple.Contains(multipleRegistrations[1]));
+            var resolved = (Registered) resolver.GetInstance(typeof (Registered));
+
+            Assert.That(resolved, Is.EqualTo(registered));
         }
 
         [Test]
         public void StructureMapResolveSingleInstance()
         {
-            var registerSingle = new RegisterSingle();
-            var multipleRegistrations = new[] { new RegisterMultiple(), new RegisterMultiple() };
+            var registered = new Registered();
 
-            ObjectFactory.Initialize(i =>
-            {
-                i.Register(registerSingle);
-                i.Register(multipleRegistrations[0]);
-                i.Register(multipleRegistrations[1]);
-            });
+            ObjectFactory.Initialize(i => i.Register(registered));
 
             var resolver = new StructureMapDependencyResolver(ObjectFactory.Container);
 
-            var resolvedSingle = (RegisterSingle)resolver.GetInstance(typeof(RegisterSingle));
-            var resolvedMultiple = resolver.GetInstances<RegisterMultiple>().ToArray();
-            Assert.That(resolvedSingle, Is.EqualTo(registerSingle));
-            Assert.That(resolvedMultiple.Count(), Is.EqualTo(2));
-            Assert.That(resolvedMultiple.Contains(multipleRegistrations[0]));
-            Assert.That(resolvedMultiple.Contains(multipleRegistrations[1]));
+            var resolved = (Registered) resolver.GetInstance(typeof (Registered));
+
+            Assert.That(resolved, Is.EqualTo(registered));
         }
 
         [Test]
         public void UnityResolveSingleInstance()
         {
             var container = new UnityContainer();
-            var registerSingle = new RegisterSingle();
-            var multipleRegistrations = new[] { new RegisterMultiple(), new RegisterMultiple() };
-            container.RegisterInstance(registerSingle);
-            //unity requires a name when registering multiple instances of the same type or nothing will be resolved.
-            container.RegisterInstance("instance1", multipleRegistrations[0]);
-            container.RegisterInstance("instance2", multipleRegistrations[1]);
+            var registered = new Registered();
+            container.RegisterInstance(registered);
 
             var resolver = new UnityDependencyResolver(container);
 
-            var resolvedSingle = (RegisterSingle)resolver.GetInstance(typeof(RegisterSingle));
-            var resolvedMultiple = resolver.GetInstances<RegisterMultiple>().ToArray();
-            Assert.That(resolvedSingle, Is.EqualTo(registerSingle));
-            Assert.That(resolvedMultiple.Count(), Is.EqualTo(2));
-            Assert.That(resolvedMultiple.Contains(multipleRegistrations[0]));
-            Assert.That(resolvedMultiple.Contains(multipleRegistrations[1]));
+            var resolved = (Registered) resolver.GetInstance(typeof (Registered));
+
+            Assert.That(resolved, Is.EqualTo(registered));
         }
 
         [Test]
         public void WindsorResolveSingleInstance()
         {
             var container = new WindsorContainer();
-            var registerSingle = new RegisterSingle();
-            var multipleRegistrations = new[] { new RegisterMultiple(), new RegisterMultiple() };
-            //windsor requires a name when registering multiple instances of the same type or nothing will be resolved.
-            container.Register(Component.For<RegisterSingle>().Instance(registerSingle));
-            container.Register(Component.For<RegisterMultiple>().Instance(multipleRegistrations[0]).Named("instance1"));
-            container.Register(Component.For<RegisterMultiple>().Instance(multipleRegistrations[1]).Named("instance2"));
+            var registered = new Registered();
+            container.Register(Component.For<Registered>().Instance(registered));
 
             var resolver = new WindsorDependencyResolver(container);
 
-            var resolvedSingle = (RegisterSingle)resolver.GetInstance(typeof(RegisterSingle));
-            var resolvedMultiple = resolver.GetInstances<RegisterMultiple>().ToArray();
-            Assert.That(resolvedSingle, Is.EqualTo(registerSingle));
-            Assert.That(resolvedMultiple.Count(), Is.EqualTo(2));
-            Assert.That(resolvedMultiple.Contains(multipleRegistrations[0]));
-            Assert.That(resolvedMultiple.Contains(multipleRegistrations[1]));
-        }
+            var resolved = (Registered) resolver.GetInstance(typeof (Registered));
 
-        class RegisterSingle
-        {
-        }
-
-        class RegisterMultiple
-        {
-            
+            Assert.That(resolved, Is.EqualTo(registered));
         }
     }
 }

--- a/ShortBus.Tests/Example/BasicExample.cs
+++ b/ShortBus.Tests/Example/BasicExample.cs
@@ -17,7 +17,7 @@ namespace ShortBus.Tests.Example
                     s.TheCallingAssembly();
                     s.WithDefaultConventions();
                     s.AddAllTypesOf((typeof (IQueryHandler<,>)));
-                    s.AddAllTypesOf(typeof (ICommandHandler<>));
+                    s.AddAllTypesOf(typeof (ICommandHandler<,>));
                 }));
 
             ShortBus.DependencyResolver.SetResolver(new StructureMapDependencyResolver(ObjectFactory.Container));
@@ -76,9 +76,25 @@ namespace ShortBus.Tests.Example
         }
 
         [Test]
-        public void Send()
+        public void Send_void()
         {
             var command = new PrintText
+                {
+                    Format = "This is a {0} message",
+                    Args = new object[] {"text"}
+                };
+
+            var mediator = ObjectFactory.GetInstance<IMediator>();
+
+            var response = mediator.Send(command);
+
+            Assert.That(response.HasException(), Is.False, response.Exception == null ? string.Empty : response.Exception.ToString());
+        }
+
+        [Test]
+        public void Send_void_variant()
+        {
+            var command = new PrintTextSpecial
                 {
                     Format = "This is a {0} message",
                     Args = new object[] {"text"}
@@ -92,19 +108,15 @@ namespace ShortBus.Tests.Example
         }
 
         [Test]
-        public void Send_variant()
+        public void Send_result()
         {
-            var command = new PrintTextSpecial
-                {
-                    Format = "This is a {0} message",
-                    Args = new object[] {"text"}
-                };
+            var command = new CommandWithResult();
 
-            var mediator = ObjectFactory.GetInstance<IMediator>();
+            var mediator = new Mediator();
 
             var response = mediator.Send(command);
 
-            Assert.That(response.HasException(), Is.False);
+            Assert.That(response.Data, Is.EqualTo("foo"));
         }
 
         [Test, Explicit]

--- a/ShortBus.Tests/Example/ConsoleWriter.cs
+++ b/ShortBus.Tests/Example/ConsoleWriter.cs
@@ -1,12 +1,20 @@
-﻿using System;
-
-namespace ShortBus.Tests.Example
+﻿namespace ShortBus.Tests.Example
 {
-    public class ConsoleWriter : ICommandHandler<PrintText>
+    using System;
+
+    public class ConsoleWriter : CommandHandler<PrintText>
     {
-        public void Handle(PrintText message)
+        protected override void HandleCore(PrintText command)
         {
-            Console.WriteLine(message.Format, message.Args);
+            Console.WriteLine(command.Format, command.Args);
+        }
+    }
+
+    public class CommandWithResultHandler : ICommandHandler<CommandWithResult, string>
+    {
+        public string Handle(CommandWithResult command)
+        {
+            return "foo";
         }
     }
 }

--- a/ShortBus.Tests/Example/Ping.cs
+++ b/ShortBus.Tests/Example/Ping.cs
@@ -1,5 +1,6 @@
 ﻿namespace ShortBus.Tests.Example
 {
-    public class Ping : IQuery<string> {}
-    public class PingALing : Ping {}
+    public class Ping : IQuery<string> { }
+
+    public class PingALing : Ping { }
 }

--- a/ShortBus.Tests/Example/PrintText.cs
+++ b/ShortBus.Tests/Example/PrintText.cs
@@ -1,6 +1,6 @@
 namespace ShortBus.Tests.Example
 {
-    public class PrintText
+    public class PrintText : ICommand
     {
         public virtual string Format { get; set; }
         public virtual object[] Args { get; set; }
@@ -15,5 +15,10 @@ namespace ShortBus.Tests.Example
             get { return _format + " is special"; }
             set { _format = value; }
         }
+    }
+
+    public class CommandWithResult : ICommand<string>
+    {
+        
     }
 }

--- a/ShortBus.Unity/UnityDependencyResolver.cs
+++ b/ShortBus.Unity/UnityDependencyResolver.cs
@@ -1,9 +1,7 @@
-﻿using Microsoft.Practices.Unity;
-
-namespace ShortBus.Unity
+﻿namespace ShortBus.Unity
 {
     using System;
-    using System.Collections.Generic;
+    using Microsoft.Practices.Unity;
 
     public class UnityDependencyResolver : IDependencyResolver
     {
@@ -17,11 +15,6 @@ namespace ShortBus.Unity
         public object GetInstance(Type type)
         {
             return _container.Resolve(type);
-        }
-
-        public IEnumerable<T> GetInstances<T>()
-        {
-            return _container.ResolveAll<T>();
         }
     }
 }

--- a/ShortBus.Windsor/WindsorDependencyResolver.cs
+++ b/ShortBus.Windsor/WindsorDependencyResolver.cs
@@ -1,9 +1,7 @@
-﻿using Castle.Windsor;
-
-namespace ShortBus.Windsor
+﻿namespace ShortBus.Windsor
 {
     using System;
-    using System.Collections.Generic;
+    using Castle.Windsor;
 
     public class WindsorDependencyResolver : IDependencyResolver
     {
@@ -17,11 +15,6 @@ namespace ShortBus.Windsor
         public object GetInstance(Type type)
         {
             return _container.Resolve(type);
-        }
-
-        public IEnumerable<T> GetInstances<T>()
-        {
-            return _container.ResolveAll<T>();
         }
     }
 }

--- a/ShortBus/DependencyResolver.cs
+++ b/ShortBus/DependencyResolver.cs
@@ -1,13 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace ShortBus
 {
+    using System;
+
     public interface IDependencyResolver
     {
         object GetInstance(Type type);
-        IEnumerable<T> GetInstances<T>();
     }
 
     public static class DependencyResolver
@@ -19,30 +16,23 @@ namespace ShortBus
             Current = resolver;
         }
 
-        public static void SetResolver(Func<Type, object> getInstance, Func<Type, IEnumerable<object>> getInstances)
+        public static void SetResolver(Func<Type, object> getInstance)
         {
-            Current = new DelegateDependencyResolver(getInstance, getInstances);
+            Current = new DelegateDependencyResolver(getInstance);
         }
 
-        private class DelegateDependencyResolver : IDependencyResolver
+        class DelegateDependencyResolver : IDependencyResolver
         {
-            private readonly Func<Type, object> _getInstance;
-            private readonly Func<Type, IEnumerable<object>> _getInstances;
+            readonly Func<Type, object> _getInstance;
 
-            public DelegateDependencyResolver(Func<Type, object> getInstance, Func<Type, IEnumerable<object>> getInstances)
+            public DelegateDependencyResolver(Func<Type, object> getInstance)
             {
                 _getInstance = getInstance;
-                _getInstances = getInstances;
             }
 
             public object GetInstance(Type type)
             {
                 return _getInstance(type);
-            }
-
-            public IEnumerable<T> GetInstances<T>()
-            {
-                return _getInstances(typeof (T)).OfType<T>();
             }
         }
     }

--- a/ShortBus/IAsyncCommandHandler.cs
+++ b/ShortBus/IAsyncCommandHandler.cs
@@ -2,8 +2,20 @@ namespace ShortBus
 {
     using System.Threading.Tasks;
 
-    public interface IAsyncCommandHandler<in TMessage>
+    public interface IAsyncCommandHandler<in TCommand, TResult> where TCommand : IAsyncCommand<TResult>
     {
-        Task HandleAsync(TMessage message);
+        Task<TResult> HandleAsync(TCommand message);
+    }
+
+    public abstract class AsyncCommandHandler<TCommand> : IAsyncCommandHandler<TCommand, UnitType>
+        where TCommand : IAsyncCommand
+    {
+        public Task<UnitType> HandleAsync(TCommand message)
+        {
+            return HandleAsyncCore(message)
+                .ContinueWith(_ => UnitType.Default);
+        }
+
+        protected abstract Task HandleAsyncCore(TCommand message);
     }
 }

--- a/ShortBus/ICommandHandler.cs
+++ b/ShortBus/ICommandHandler.cs
@@ -1,7 +1,20 @@
 namespace ShortBus
 {
-    public interface ICommandHandler<in TMessage>
+    public interface ICommandHandler<in TCommand, out TResult>
     {
-        void Handle(TMessage message);
+        TResult Handle(TCommand command);
+    }
+
+    public interface ICommandHandler<in TCommand> : ICommandHandler<TCommand, UnitType> { }
+
+    public abstract class CommandHandler<TCommand> : ICommandHandler<TCommand>
+    {
+        public UnitType Handle(TCommand command)
+        {
+            HandleCore(command);
+            return UnitType.Default;
+        }
+
+        protected abstract void HandleCore(TCommand command);
     }
 }

--- a/ShortBus/IMediator.cs
+++ b/ShortBus/IMediator.cs
@@ -7,7 +7,7 @@
         Response<TResponseData> Request<TResponseData>(IQuery<TResponseData> query);
         Task<Response<TResponseData>> RequestAsync<TResponseData>(IAsyncQuery<TResponseData> query);
 
-        Response Send<TMessage>(TMessage message);
-        Task<Response> SendAsync<TMessage>(TMessage message);
+        Response<TResponseData> Send<TResponseData>(ICommand<TResponseData> command);
+        Task<Response<TResponseData>> SendAsync<TResponseData>(IAsyncCommand<TResponseData> command);
     }
 }

--- a/ShortBus/Response.cs
+++ b/ShortBus/Response.cs
@@ -1,19 +1,18 @@
-using System;
-
 namespace ShortBus
 {
-    public class Response
+    using System;
+
+    public sealed class Response : Response<UnitType> { }
+
+    public class Response<TResponseData>
     {
+        public virtual TResponseData Data { get; set; }
+
         public virtual Exception Exception { get; set; }
 
         public virtual bool HasException()
         {
             return Exception != null;
         }
-    }
-
-    public class Response<TResponseData> : Response
-    {
-        public virtual TResponseData Data { get; set; }
     }
 }


### PR DESCRIPTION
... based on our needs and ideas in
http://lostechies.com/jimmybogard/2013/12/19/put-your-controllers-on-a-diet-posts-and-commands/
1. one command to one command handler
2. commands have a result
   - newly introduced UnitType represents void
   - the introduction of CommandHandler<T> and AsyncCommandHandler<T> should ease migration
