### PR TITLE
Providing greater control over DI lifetime scope

### DIFF
--- a/ShortBus.Autofac/AutofacDependencyResolver.cs
+++ b/ShortBus.Autofac/AutofacDependencyResolver.cs
@@ -5,9 +5,9 @@ namespace ShortBus.Autofac
 
     public class AutofacDependencyResolver : IDependencyResolver
     {
-        readonly IContainer _container;
+        readonly ILifetimeScope _container;
 
-        public AutofacDependencyResolver(IContainer container)
+        public AutofacDependencyResolver(ILifetimeScope container)
         {
             _container = container;
         }

--- a/ShortBus.Tests/Example/AsyncExample.cs
+++ b/ShortBus.Tests/Example/AsyncExample.cs
@@ -1,7 +1,6 @@
 ﻿namespace ShortBus.Tests.Example
 {
     using System;
-    using System.Threading;
     using System.Threading.Tasks;
     using global::StructureMap;
     using NUnit.Framework;
@@ -16,14 +15,14 @@
             ObjectFactory.Initialize(i => i.Scan(s =>
             {
                 s.TheCallingAssembly();
-                s.AddAllTypesOf(( typeof (IAsyncQueryHandler<,>) ));
+                s.AddAllTypesOf((typeof(IAsyncQueryHandler<,>)));
             }));
 
-            DependencyResolver.SetResolver(new StructureMapDependencyResolver(ObjectFactory.Container));
+            var resolver = new StructureMapDependencyResolver(ObjectFactory.Container);
 
             var query = new ExternalResourceQuery();
 
-            var mediator = new Mediator();
+            var mediator = new Mediator(resolver);
 
             var task = mediator.RequestAsync(query);
 
@@ -37,14 +36,14 @@
             ObjectFactory.Initialize(i => i.Scan(s =>
             {
                 s.TheCallingAssembly();
-                s.AddAllTypesOf(( typeof (IAsyncCommandHandler<,>) ));
+                s.AddAllTypesOf((typeof(IAsyncCommandHandler<,>)));
             }));
 
-            DependencyResolver.SetResolver(new StructureMapDependencyResolver(ObjectFactory.Container));
+            var resolver = new StructureMapDependencyResolver(ObjectFactory.Container);
 
             var query = new AddResource();
 
-            var mediator = new Mediator();
+            var mediator = new Mediator(resolver);
 
             var result = mediator.SendAsync(query).Result;
 

--- a/ShortBus.Tests/Example/AutofacBasicExample.cs
+++ b/ShortBus.Tests/Example/AutofacBasicExample.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Autofac;
+using Autofac.Features.Variance;
+using NUnit.Framework;
+using ShortBus.Autofac;
+
+namespace ShortBus.Tests.Example
+{
+    [TestFixture]
+    public class AutofacBasicExample
+    {
+        private ILifetimeScope RootScope { get; set; }
+        private ILifetimeScope TestScope { get; set; }
+
+        [TestFixtureSetUp]
+        public void SetUpRootScope()
+        {
+            var builder = new ContainerBuilder();
+
+            // this is needed to allow the Mediator to resolve contravariant handlers (not enabled by default in Autofac)
+            builder.RegisterSource(new ContravariantRegistrationSource());
+
+            builder.RegisterAssemblyTypes(typeof (IMediator).Assembly, GetType().Assembly)
+                .AsClosedTypesOf(typeof (IQueryHandler<,>))
+                .AsImplementedInterfaces();
+
+            builder.RegisterAssemblyTypes(typeof (IMediator).Assembly, GetType().Assembly)
+                .AsClosedTypesOf(typeof (ICommandHandler<,>))
+                .AsImplementedInterfaces();
+
+            builder.RegisterType<Mediator>().AsImplementedInterfaces().InstancePerLifetimeScope();
+
+            // to allow ShortBus to resolve lifetime-scoped dependencies properly, 
+            // we really can't use the default approach of setting the static (global) dependency resolver, 
+            // since that resolves instances from the root scope passed into it, rather than 
+            // the current lifetime scope at the time of resolution.  
+            // Resolving from the root scope can cause resource leaks, or in the case of components with a 
+            // specific scope affinity (AutofacWebRequest, for example) it would fail outright, 
+            // since that scope doesn't exist at the root level.
+            builder.RegisterType<AutofacDependencyResolver>()
+                .AsImplementedInterfaces()
+                .InstancePerLifetimeScope();
+
+            RootScope = builder.Build();
+
+            RootScope.ComponentRegistry.Sources.ToList()
+                .ForEach(s => Console.WriteLine("{0} ({1})", s.GetType().Name, s));
+        }
+
+        [TestFixtureTearDown]
+        public void TearDownRootScope()
+        {
+            RootScope.Dispose();
+            RootScope = null;
+        }
+
+        [SetUp]
+        public void BeginTestScope()
+        {
+            TestScope = RootScope.BeginLifetimeScope("testScope");
+        }
+
+        [TearDown]
+        public void EndTestScope()
+        {
+            TestScope.Dispose();
+            TestScope = null;
+        }
+
+        [Test]
+        public void RequestResponse()
+        {
+            var query = new Ping();
+
+            var mediator = TestScope.Resolve<IMediator>();
+
+            var pong = mediator.Request(query);
+
+            Assert.That(pong.HasException(), Is.False,
+                pong.Exception == null ? string.Empty : pong.Exception.ToString());
+            Assert.That(pong.Data, Is.EqualTo("PONG!"));
+        }
+
+        [Test]
+        public void RequestResponseImplementationWithMultipleHandler()
+        {
+            var query = new TriplePing();
+
+            var mediator = TestScope.Resolve<IMediator>();
+
+            var pong = mediator.Request(query);
+
+            Assert.That(pong.HasException(), Is.False,
+                pong.Exception == null ? string.Empty : pong.Exception.ToString());
+            Assert.That(pong.Data, Is.EqualTo("PONG! PONG! PONG!"));
+        }
+
+        [Test]
+        public void RequestResponse_variant()
+        {
+            var query = new PingALing();
+
+            var mediator = TestScope.Resolve<IMediator>();
+
+            var pong = mediator.Request(query);
+
+            Assert.That(pong.HasException(), Is.False,
+                pong.Exception == null ? string.Empty : pong.Exception.ToString());
+            Assert.That(pong.Data, Is.EqualTo("PONG!"));
+        }
+
+        [Test]
+        public void RequestResponseImplementationWithMultipleHandler_variant()
+        {
+            var query = new DoublePingALing();
+
+            var mediator = TestScope.Resolve<IMediator>();
+
+            var pong = mediator.Request(query);
+
+            Assert.That(pong.HasException(), Is.False,
+                pong.Exception == null ? string.Empty : pong.Exception.ToString());
+            Assert.That(pong.Data, Is.EqualTo("PONG! PONG!"));
+        }
+
+        [Test]
+        public void Send_void()
+        {
+            var command = new PrintText
+            {
+                Format = "This is a {0} message",
+                Args = new object[] {"text"}
+            };
+
+            var mediator = TestScope.Resolve<IMediator>();
+
+            var response = mediator.Send(command);
+
+            Assert.That(response.HasException(), Is.False,
+                response.Exception == null ? string.Empty : response.Exception.ToString());
+        }
+
+        [Test]
+        public void Send_void_variant()
+        {
+            var command = new PrintTextSpecial
+            {
+                Format = "This is a {0} message",
+                Args = new object[] {"text"}
+            };
+
+            var mediator = TestScope.Resolve<IMediator>();
+
+            var response = mediator.Send(command);
+
+            Assert.That(response.HasException(), Is.False,
+                response.Exception == null ? string.Empty : response.Exception.ToString());
+        }
+
+        [Test]
+        public void Send_result()
+        {
+            var command = new CommandWithResult();
+
+            var mediator = TestScope.Resolve<IMediator>();
+
+            var response = mediator.Send(command);
+
+            Assert.That(response.Data, Is.EqualTo("foo"),
+                response.Exception == null ? string.Empty : response.Exception.ToString());
+        }
+
+        [Test, Explicit]
+        public void Perf()
+        {
+            var mediator = TestScope.Resolve<IMediator>();
+            var query = new Ping();
+
+            var watch = Stopwatch.StartNew();
+
+            for (var i = 0; i < 10000; i++)
+                mediator.Request(query);
+
+            watch.Stop();
+
+            Console.WriteLine(watch.Elapsed);
+        }
+    }
+}

--- a/ShortBus.Tests/Example/BasicExample.cs
+++ b/ShortBus.Tests/Example/BasicExample.cs
@@ -11,14 +11,19 @@ namespace ShortBus.Tests.Example
     {
         public BasicExample()
         {
-            ObjectFactory.Initialize(i => i.Scan(s =>
+            ObjectFactory.Initialize(i =>
+            {
+                i.Scan(s =>
                 {
                     s.AssemblyContainingType<IMediator>();
                     s.TheCallingAssembly();
                     s.WithDefaultConventions();
-                    s.AddAllTypesOf((typeof (IQueryHandler<,>)));
-                    s.AddAllTypesOf(typeof (ICommandHandler<,>));
-                }));
+                    s.AddAllTypesOf((typeof(IQueryHandler<,>)));
+                    s.AddAllTypesOf(typeof(ICommandHandler<,>));
+                });
+
+                i.For<IDependencyResolver>().Use(() => DependencyResolver.Current);
+            });
 
             ShortBus.DependencyResolver.SetResolver(new StructureMapDependencyResolver(ObjectFactory.Container));
         }
@@ -79,10 +84,10 @@ namespace ShortBus.Tests.Example
         public void Send_void()
         {
             var command = new PrintText
-                {
-                    Format = "This is a {0} message",
-                    Args = new object[] {"text"}
-                };
+            {
+                Format = "This is a {0} message",
+                Args = new object[] { "text" }
+            };
 
             var mediator = ObjectFactory.GetInstance<IMediator>();
 
@@ -95,10 +100,10 @@ namespace ShortBus.Tests.Example
         public void Send_void_variant()
         {
             var command = new PrintTextSpecial
-                {
-                    Format = "This is a {0} message",
-                    Args = new object[] {"text"}
-                };
+            {
+                Format = "This is a {0} message",
+                Args = new object[] { "text" }
+            };
 
             var mediator = ObjectFactory.GetInstance<IMediator>();
 
@@ -112,7 +117,7 @@ namespace ShortBus.Tests.Example
         {
             var command = new CommandWithResult();
 
-            var mediator = new Mediator();
+            var mediator = new Mediator(DependencyResolver.Current);
 
             var response = mediator.Send(command);
 

--- a/ShortBus.Tests/ShortBus.Tests.csproj
+++ b/ShortBus.Tests/ShortBus.Tests.csproj
@@ -74,6 +74,7 @@
   <ItemGroup>
     <Compile Include="Containers\ContainerTests.cs" />
     <Compile Include="Example\AsyncExample.cs" />
+    <Compile Include="Example\AutofacBasicExample.cs" />
     <Compile Include="Example\BasicExample.cs" />
     <Compile Include="Example\ConsoleWriter.cs" />
     <Compile Include="Example\MultiPong.cs" />


### PR DESCRIPTION
Changed AutofacDependencyResolver ctor to take ILifetimeScope instead of IContainer, providing greater flexibility, as IContainer can only be used at the root level in Autofac.
Also, injected IDependencyResolver into Mediator ctor, to allow mediator to resolve dependencies from various lifetime scopes, as determined by consuming devs.
