### PR TITLE
Updated StructureMap to version 3.1.1.134

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,29 @@
 ## ShortBus
 ShortBus is an in-process mediator with low-friction API
 
-### Command
-    public class DoSomething : ICommand { }
+### Requests
+    public class DoSomething : IRequest<UnitType> { }
 
-	public class DoesSomething : ICommandHandler<DoSomething> {
-		public void Handle(DoSomething command) {
+	public class DoesSomething : IRequestHandler<DoSomething, UnitType> {
+		public UnitType Handle(DoSomething request) {
 		   // does something
+		   return UnitType.Default; // Similar to void
 		}
 	}
 
     _mediator.Send(new DoSomething());
 
+### Notifications
+    public class NotifySomething { }
 
+    public class NotificationHandler : INotificationHandler<NotifySomething> {
+        public void Handle(NotifySomething notification) {
+            // does something
+        }
+    }
 
-### Query
-    public class AskAQuestion : IQuery<Answer> { }
+    _mediator.Notify(new NotifySomething());
 
-	public class Answerer : IQueryHandler<AskAQuestion, Answer> {
-	    public Answer Handle(AskAQuestion query) {			
-			return answer;
-		}
-	}
-
-	var answer = _mediator.Request(new AskAQuestion());
-	
 ### IOC Containers
 
 ShortBus currently supports 6 IOC containers
@@ -38,14 +37,15 @@ ShortBus currently supports 6 IOC containers
 
 Example configuration of registering handlers using StructureMap:
 
-    ObjectFactory.Initialize(i => i.Scan(s =>
+    var container = new Container();
+    container.Configure(i => i.Scan(s =>
     {
         s.AssemblyContainingType<IMediator>();
-        s.TheCallingAssembly();
+        s.Assembly(Assembly.GetExecutingAssembly());
         s.WithDefaultConventions();
-        s.AddAllTypesOf(typeof (IQueryHandler<,>));
-        s.AddAllTypesOf(typeof (ICommandHandler<>));
-    }));	
+        s.ConnectImplementationsToTypesClosing(typeof(IRequestHandler<,>));
+        s.ConnectImplementationsToTypesClosing(typeof(INotificationHandler<>));
+    }));
 
 ### Low-friction API
 No type parameter noise.

--- a/ShortBus.StructureMap/ShortBus.StructureMap.csproj
+++ b/ShortBus.StructureMap/ShortBus.StructureMap.csproj
@@ -33,7 +33,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="StructureMap">
-      <HintPath>..\packages\structuremap.2.6.3\lib\StructureMap.dll</HintPath>
+      <HintPath>..\packages\structuremap.3.1.1.134\lib\net40\StructureMap.dll</HintPath>
+    </Reference>
+    <Reference Include="StructureMap.Net4">
+      <HintPath>..\packages\structuremap.3.1.1.134\lib\net40\StructureMap.Net4.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -48,13 +51,13 @@
     <Compile Include="StructureMapDependencyResolver.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\ShortBus\ShortBus.csproj">
       <Project>{50078B66-DBAC-4273-8DD0-970176B2FE2B}</Project>
       <Name>ShortBus</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/ShortBus.StructureMap/packages.config
+++ b/ShortBus.StructureMap/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="structuremap" version="2.6.3" targetFramework="net45" />
+  <package id="structuremap" version="3.1.1.134" targetFramework="net45" />
 </packages>

--- a/ShortBus.Tests/Containers/ContainerTests.cs
+++ b/ShortBus.Tests/Containers/ContainerTests.cs
@@ -53,11 +53,12 @@ namespace ShortBus.Tests.Containers
         [Test]
         public void StructureMapResolveSingleInstance()
         {
+            var container = new Container();
+
             var registered = new Registered();
+            container.Inject(registered);
 
-            ObjectFactory.Initialize(i => i.Register(registered));
-
-            var resolver = new StructureMapDependencyResolver(ObjectFactory.Container);
+            var resolver = new StructureMapDependencyResolver(container);
 
             var resolved = (Registered) resolver.GetInstance(typeof (Registered));
 

--- a/ShortBus.Tests/Example/AsyncExample.cs
+++ b/ShortBus.Tests/Example/AsyncExample.cs
@@ -6,6 +6,7 @@
     using global::StructureMap;
     using NUnit.Framework;
     using StructureMap;
+    using System.Reflection;
 
     [TestFixture]
     public class AsyncExample
@@ -14,18 +15,18 @@
         public void Notification()
         {
             var handled = new List<int>();
-
-            ObjectFactory.Initialize(i =>
+            var container = new Container();
+            container.Configure(i =>
             {
                 i.Scan(s =>
                 {
-                    s.TheCallingAssembly();
+                    s.Assembly(Assembly.GetExecutingAssembly());
                     s.AddAllTypesOf(( typeof (INotificationHandler<>) ));
                 });
                 i.For<IList>().Use(handled);
             });
 
-            var resolver = new StructureMapDependencyResolver(ObjectFactory.Container);
+            var resolver = new StructureMapDependencyResolver(container);
 
             var notification = new Notification();
 
@@ -33,19 +34,20 @@
 
             mediator.Notify(notification);
 
-            CollectionAssert.AreEquivalent(handled, new[]{1,2});
+            CollectionAssert.AreEquivalent(new[] { 1, 2 }, handled);
         }
 
         [Test]
         public void RequestResponse()
         {
-            ObjectFactory.Initialize(i => i.Scan(s =>
+            var container = new Container();
+            container.Configure(i => i.Scan(s =>
             {
-                s.TheCallingAssembly();
+                s.Assembly(Assembly.GetExecutingAssembly());
                 s.AddAllTypesOf(( typeof (IAsyncRequestHandler<,>) ));
             }));
 
-            var resolver = new StructureMapDependencyResolver(ObjectFactory.Container);
+            var resolver = new StructureMapDependencyResolver(container);
 
             var query = new ExternalResourceQuery();
 

--- a/ShortBus.Tests/Example/BasicExample.cs
+++ b/ShortBus.Tests/Example/BasicExample.cs
@@ -3,29 +3,33 @@ using System.Diagnostics;
 using NUnit.Framework;
 using ShortBus.StructureMap;
 using StructureMap;
+using System.Reflection;
 
 namespace ShortBus.Tests.Example
 {
     [TestFixture]
     public class BasicExample
     {
+        private readonly IContainer _container;
         public BasicExample()
         {
-            ObjectFactory.Initialize(i =>
+            _container = new Container();
+
+            _container.Configure(i =>
             {
                 i.Scan(s =>
                 {
                     s.AssemblyContainingType<IMediator>();
-                    s.TheCallingAssembly();
+                    s.Assembly(Assembly.GetExecutingAssembly());
                     s.WithDefaultConventions();
-                    s.AddAllTypesOf((typeof(IRequestHandler<,>)));
-                    s.AddAllTypesOf(typeof(INotificationHandler<>));
+                    s.ConnectImplementationsToTypesClosing(typeof(IRequestHandler<,>));
+                    s.ConnectImplementationsToTypesClosing(typeof(INotificationHandler<>));
                 });
 
                 i.For<IDependencyResolver>().Use(() => DependencyResolver.Current);
             });
 
-            ShortBus.DependencyResolver.SetResolver(new StructureMapDependencyResolver(ObjectFactory.Container));
+            ShortBus.DependencyResolver.SetResolver(new StructureMapDependencyResolver(_container));
         }
 
         [Test]
@@ -33,7 +37,7 @@ namespace ShortBus.Tests.Example
         {
             var query = new Ping();
 
-            var mediator = ObjectFactory.GetInstance<IMediator>();
+            var mediator = _container.GetInstance<IMediator>();
 
             var pong = mediator.Request(query);
 
@@ -46,7 +50,7 @@ namespace ShortBus.Tests.Example
         {
             var query = new TriplePing();
 
-            var mediator = ObjectFactory.GetInstance<IMediator>();
+            var mediator = _container.GetInstance<IMediator>();
 
             var pong = mediator.Request(query);
 
@@ -59,7 +63,7 @@ namespace ShortBus.Tests.Example
         {
             var query = new PingALing();
 
-            var mediator = ObjectFactory.GetInstance<IMediator>();
+            var mediator = _container.GetInstance<IMediator>();
 
             var pong = mediator.Request(query);
 
@@ -72,7 +76,7 @@ namespace ShortBus.Tests.Example
         {
             var query = new DoublePingALing();
 
-            var mediator = ObjectFactory.GetInstance<IMediator>();
+            var mediator = _container.GetInstance<IMediator>();
 
             var pong = mediator.Request(query);
 
@@ -89,7 +93,7 @@ namespace ShortBus.Tests.Example
                 Args = new object[] { "text" }
             };
 
-            var mediator = ObjectFactory.GetInstance<IMediator>();
+            var mediator = _container.GetInstance<IMediator>();
 
             var response = mediator.Request(command);
 
@@ -105,7 +109,7 @@ namespace ShortBus.Tests.Example
                 Args = new object[] { "text" }
             };
 
-            var mediator = ObjectFactory.GetInstance<IMediator>();
+            var mediator = _container.GetInstance<IMediator>();
 
             var response = mediator.Request(command);
 
@@ -127,7 +131,7 @@ namespace ShortBus.Tests.Example
         [Test, Explicit]
         public void Perf()
         {
-            var mediator = ObjectFactory.GetInstance<IMediator>();
+            var mediator = _container.GetInstance<IMediator>();
             var query = new Ping();
 
             var watch = Stopwatch.StartNew();

--- a/ShortBus.Tests/ShortBus.Tests.csproj
+++ b/ShortBus.Tests/ShortBus.Tests.csproj
@@ -71,7 +71,10 @@
       <HintPath>..\packages\SimpleInjector.2.5.0\lib\net45\SimpleInjector.Diagnostics.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap">
-      <HintPath>..\packages\structuremap.2.6.3\lib\StructureMap.dll</HintPath>
+      <HintPath>..\packages\structuremap.3.1.1.134\lib\net40\StructureMap.dll</HintPath>
+    </Reference>
+    <Reference Include="StructureMap.Net4">
+      <HintPath>..\packages\structuremap.3.1.1.134\lib\net40\StructureMap.Net4.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -93,7 +96,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShortBus.Autofac\ShortBus.Autofac.csproj">
       <Project>{0A3CE491-085A-460C-BEE8-D577DFB0244D}</Project>

--- a/ShortBus.Tests/packages.config
+++ b/ShortBus.Tests/packages.config
@@ -6,6 +6,6 @@
   <package id="Ninject" version="3.0.1.10" targetFramework="net45" />
   <package id="NUnit" version="2.5.9.10348" />
   <package id="SimpleInjector" version="2.5.0" targetFramework="net45" />
-  <package id="structuremap" version="2.6.3" />
+  <package id="structuremap" version="3.1.1.134" targetFramework="net45" />
   <package id="Unity" version="3.0.1304.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Installing the prerelease packages from NuGet automatically pulls in the
latest stable version of StructureMap. However, the ShortBus.StructureMap
package is built against an old version of StructureMap (2.6.3). This
commit updates to the current latest stable release of StructureMap and
updates the tests and examples by removing deprecated features.

Signed-off-by: Jos van der Til jos@vandertil.eu
