### PR TITLE
Updated unity resolver to resolve all instances

### DIFF
--- a/ShortBus.Tests/Containers/ContainerTests.cs
+++ b/ShortBus.Tests/Containers/ContainerTests.cs
@@ -14,13 +14,18 @@ namespace ShortBus.Tests.Containers
     using Unity;
     using Windsor;
 	using SimpleInjector;
+    using System.Linq;
 
     [TestFixture]
     public class ContainerTests
     {
         public ContainerTests() { }
 
-        class Registered { }
+        interface IRegistered { }
+
+        class Registered : IRegistered { }
+
+        class Registered2 : IRegistered { }
 
         [Test]
         public void AutofacResolveSingleInstance()
@@ -76,6 +81,20 @@ namespace ShortBus.Tests.Containers
             var resolved = (Registered) resolver.GetInstance(typeof (Registered));
 
             Assert.That(resolved, Is.EqualTo(registered));
+        }
+
+        [Test]
+        public void UnityResolveMultipleTypes()
+        {
+            var container = new UnityContainer();
+            container.RegisterType<IRegistered, Registered>();
+            container.RegisterType<IRegistered, Registered2>("secondType");
+
+            var resolver = new UnityDependencyResolver(container);
+
+            var resolved = resolver.GetInstances<IRegistered>();
+
+            Assert.That(resolved.Count(), Is.EqualTo(2));
         }
 
         [Test]

--- a/ShortBus.Unity/UnityDependencyResolver.cs
+++ b/ShortBus.Unity/UnityDependencyResolver.cs
@@ -20,7 +20,18 @@
 
         public IEnumerable<T> GetInstances<T>()
         {
-            return _container.ResolveAll<T>();
+            List<T> results = new List<T>(_container.ResolveAll<T>());
+
+            try
+            {
+                results.Add(_container.Resolve<T>()); // needed to resolve unnamed instances.
+            }
+            catch(ResolutionFailedException)
+            {
+                // Unity throws an error if it can't resolve a type. In this case we don't care if it failed to resolve.
+            }
+
+            return results;
         }
     }
 }


### PR DESCRIPTION
Updated UnityDependencyResolver's GetInstances method so it will return
all the instances both named and unnamed in the unity container. The original functionality would have only pulled in the named instances which could cause some confusion since the other DI frameworks would have pulled in everything. This should resolve mhinze/ShortBus#36 
